### PR TITLE
Reference password in account_auth_local

### DIFF
--- a/pyrpgwnn/model/__init__.py
+++ b/pyrpgwnn/model/__init__.py
@@ -35,6 +35,30 @@ class AccountAuth(db.Model):
     account_id = db.Column(db.Integer, db.ForeignKey('account.account_id'))
     auth_type = db.Column(db.String(10), nullable=False)
 
+    def get_class_by_tablename(self, tablename):
+        """Return class reference mapped to table.
+
+        :param tablename: String with name of table.
+        :return: Class reference or None.
+        """
+        for c in db.Model._decl_class_registry.values():
+            if hasattr(c, '__tablename__') and c.__tablename__ == tablename:
+                return c
+
+    def auth_info(self):
+        """Returns the object from the relevant auth class
+
+        :return: Object from db or None
+        """
+        authclass = self.get_class_by_tablename( "account_auth_" + self.auth_type )
+        if authclass == None:
+            # Non-existant authentication method
+            return None
+        return authclass.query.filter_by( account_auth_id = self.account_auth_id ).one()
+
+    def __repr__(self):
+        return '<AccountAuth %d (type: %r)>' % ( self.account_auth_id, self.auth_type )
+
 class AccountAuthLocal(db.Model):
     __tablename__ = 'account_auth_local'
     id = db.Column(db.Integer, primary_key=True)
@@ -42,6 +66,9 @@ class AccountAuthLocal(db.Model):
     # Extra parameters required specifically for this auth method
     # Encrypted password
     password = db.Column(db.String(255), nullable=False)
+
+    def __repr__(self):
+        return '<AccountAuthLocal %d (%r)>' % ( self.id, self.password )
 
 class Character(db.Model):
     character_id = db.Column(db.Integer, primary_key=True)

--- a/pyrpgwnn/views.py
+++ b/pyrpgwnn/views.py
@@ -1,4 +1,4 @@
-from flask import render_template, redirect, url_for, request, g
+from flask import render_template, redirect, url_for, request, g, flash
 from flask.ext.login import login_user, logout_user, current_user, login_required
 from pyrpgwnn import app, db, login_manager, flask_bcrypt
 from pyrpgwnn.model import Account
@@ -143,7 +143,7 @@ def login_local():
         account = Account.query.filter_by(email = form.email.data).first()
         print(account)
         # if account and flask_bcrypt.check_password_hash(account.password, form.password.data):
-        if account and flask_bcrypt.check_password_hash('$2a$12$NmPLLbCTttv74jLV.5KojusYErzFwCyz6Iqi5Q3f19ZHrSJqfSwRe', form.password.data):
+        if account and flask_bcrypt.check_password_hash(account.account_auths.filter_by(auth_type='local').one().auth_info().password, form.password.data):
             print("authenticated")
             account.authenticated = True
             # this saves the account object in the db.. eg for 'last login' timestamps.
@@ -152,6 +152,8 @@ def login_local():
             #db.session.commit()
             login_user(account, remember=True)
             return redirect(url_for('account'))
+        else:
+            flash('Incorrect email or password')
 
     # return flask.render_template('login_local.html', form=form)
     return render_template('login_local.html', form=form)


### PR DESCRIPTION
...instead of hardcoded one. Still no way to insert password
and link entry but can be done manually as follows.

sqlite3 pyrpgwnn/rpgwnn.db
insert into account_auth values(1,1,'local');
insert into account_auth_local values(1,1,'$2a$12$NmPLLbCTttv74jLV.5KojusYErzFwCyz6Iqi5Q3f19ZHrSJqfSwRe')

This is the same password as the hardcoded one and assumes that your account is id 1.
